### PR TITLE
Test with actively maintained Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 
 matrix:
   include:
-    - python: "3.6"
+    - python: "3.7"
+    - python: "3.8"
   allow_failures:
     - python: "nightly"
 


### PR DESCRIPTION
Python 3.8 was released recently. Python 3.6 is now in security
releases only mode.