### PR TITLE
Use video URI as URL again and fix resolution fallback

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vimeo" name="Vimeo" version="5.1.2" provider-name="jaylinski">
+<addon id="plugin.video.vimeo" name="Vimeo" version="5.1.3" provider-name="jaylinski">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.future" version="0.16.0"/>
@@ -17,7 +17,11 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=220437</forum>
         <website>https://vimeo.com</website>
         <source>https://github.com/jaylinski/kodi-addon-vimeo</source>
-        <news>5.1.2 (2020-03-02)
+        <news>5.1.3 (2020-03-29)
+FIX: Use H264 fallback if video resolution is not available
+FIX: Videos are now marked as watched again
+
+5.1.2 (2020-03-02)
 FIX: Add fallback for videos without a HLS stream
 FIX: Use correct localization in info view
 

--- a/resources/lib/kodi/items.py
+++ b/resources/lib/kodi/items.py
@@ -1,11 +1,11 @@
 from future import standard_library
 standard_library.install_aliases()  # noqa: E402
 
-from resources.lib.kodi.utils import format_bold
-from resources.routes import *
-
 import urllib.parse
 import xbmcgui
+
+from resources.lib.kodi.utils import format_bold
+from resources.routes import *
 
 
 class Items:

--- a/resources/lib/models/channel.py
+++ b/resources/lib/models/channel.py
@@ -1,9 +1,10 @@
 from future import standard_library
 standard_library.install_aliases()  # noqa: E402
 
-from resources.lib.models.list_item import ListItem
 import urllib.parse
 import xbmcgui
+
+from resources.lib.models.list_item import ListItem
 
 
 class Channel(ListItem):

--- a/resources/lib/models/group.py
+++ b/resources/lib/models/group.py
@@ -1,9 +1,10 @@
 from future import standard_library
 standard_library.install_aliases()  # noqa: E402
 
-from resources.lib.models.list_item import ListItem
 import urllib.parse
 import xbmcgui
+
+from resources.lib.models.list_item import ListItem
 
 
 class Group(ListItem):

--- a/resources/lib/models/user.py
+++ b/resources/lib/models/user.py
@@ -1,9 +1,10 @@
 from future import standard_library
 standard_library.install_aliases()  # noqa: E402
 
-from resources.lib.models.list_item import ListItem
 import urllib.parse
 import xbmcgui
+
+from resources.lib.models.list_item import ListItem
 
 
 class User(ListItem):

--- a/resources/lib/models/video.py
+++ b/resources/lib/models/video.py
@@ -1,10 +1,11 @@
 from future import standard_library
 standard_library.install_aliases()  # noqa: E402
 
-from resources.lib.models.list_item import ListItem
 import urllib.parse
 import xbmcaddon
 import xbmcgui
+
+from resources.lib.models.list_item import ListItem
 
 trailer = xbmcaddon.Addon().getLocalizedString(30902)
 
@@ -39,9 +40,6 @@ class Video(ListItem):
         list_item.setProperty("isPlayable", "true")
         list_item.setProperty("mediaUrl", self.uri)
 
-        if self.info.get("mediaUrlResolved"):
-            url = self.uri
-        else:
-            url = addon_base + "/play/?" + urllib.parse.urlencode({"uri": self.uri})
+        url = addon_base + "/play/?" + urllib.parse.urlencode({"uri": self.uri})
 
         return url, list_item, False

--- a/resources/lib/models/video.py
+++ b/resources/lib/models/video.py
@@ -32,7 +32,6 @@ class Video(ListItem):
         list_item.setInfo("video", {
             "artist": [self.info.get("user", "")],
             "duration": self.info.get("duration"),
-            "playcount": self.info.get("playcount"),
             "plot": self.info.get("description", ""),
             "title": self.label,
             "year": self.info.get("date")[:4],

--- a/resources/lib/vimeo/api.py
+++ b/resources/lib/vimeo/api.py
@@ -19,6 +19,7 @@ class Api:
 
     api_player = "https://player.vimeo.com"
     api_limit = 10
+    api_fallback = False
 
     # Extracted from public Vimeo Android App
     # This is a special client ID which will return playable URLs
@@ -46,6 +47,8 @@ class Api:
 
     @property
     def api_client(self):
+        self.api_fallback = False
+
         # It is possible to set a custom access token in the settings
         access_token_settings = self.settings.get("api.accesstoken")
         if access_token_settings:
@@ -76,6 +79,7 @@ class Api:
             pass
 
         # Fallback
+        self.api_fallback = True
         return VimeoClient(token=self.api_access_token_default)
 
     @property
@@ -106,22 +110,22 @@ class Api:
         return self._map_json_to_collection(res)
 
     def resolve_media_url(self, uri):
-        # If we have a full URL, we don't need to resolve it, because it already is
-        if uri.startswith("https://"):
-            xbmc.log("plugin.video.vimeo::Api() directly resolved", xbmc.LOGDEBUG)
-            return uri
-
         # If we have a on-demand URL, we need to fetch the trailer and return the uri
         if uri.startswith("/ondemand/"):
             xbmc.log("plugin.video.vimeo::Api() resolving on-demand", xbmc.LOGDEBUG)
             return self._get_on_demand_trailer(uri)
 
         # Fallback
-        xbmc.log("plugin.video.vimeo::Api() resolving fallback", xbmc.LOGDEBUG)
-        uri = uri.replace("/videos/", "/video/")
-        res = self._do_player_request(uri)
+        if self.api_fallback:
+            xbmc.log("plugin.video.vimeo::Api() resolving fallback", xbmc.LOGDEBUG)
+            uri = uri.replace("/videos/", "/video/")
+            res = self._do_player_request(uri)
+            return self._extract_url_from_video_config(res)
 
-        return self._extract_url_from_video_config(res)
+        xbmc.log("plugin.video.vimeo::Api() resolving video uri", xbmc.LOGDEBUG)
+        params = self._get_default_params()
+        res = self._do_api_request(uri, params)
+        return self._extract_url_from_search_response(res["play"])
 
     def resolve_id(self, video_id):
         params = self._get_default_params()
@@ -153,16 +157,11 @@ class Api:
                 is_group = "/groups/" in item.get("uri", "")
                 is_user = item.get("account", False)
 
-                # Requests made with the fallback token won't include media URLs:
-                contains_media_url = "play" in item and item["play"]["status"] == "playable"
-
                 # On-demand videos don't contain playable video links:
                 purchase_required = item.get("play", {}).get("status", "") == "purchase_required"
 
                 if is_video:
-                    if contains_media_url:
-                        video_url = self._extract_url_from_search_response(item.get("play"))
-                    elif purchase_required:
+                    if purchase_required:
                         video_url = item["metadata"]["connections"]["trailer"]["uri"]
                     else:
                         video_url = item["uri"]
@@ -177,7 +176,6 @@ class Api:
                         "picture": self._get_picture(item["pictures"], 4),
                         "user": item["user"]["name"],
                         "userThumb": self._get_picture(item["user"]["pictures"], 3),
-                        "mediaUrlResolved": contains_media_url,
                         "onDemand": purchase_required,
                     }
                     collection.items.append(video)
@@ -221,22 +219,13 @@ class Api:
 
         return collection
 
-    def _get_default_params(self):
-        return {
-            "per_page": self.api_limit,
-            "total": self.api_limit,
-            # Avoid rate limiting:
-            # https://developer.vimeo.com/guidelines/rate-limiting#avoid-rate-limiting
-            "fields": "uri,resource_key,name,description,type,duration,created_time,location,"
-                      "bio,stats,user,account,release_time,pictures,metadata,play"
-        }
+    def _get_on_demand_trailer(self, uri):
+        res = self._do_api_request(uri, {"fields": "uri,type,play"})
+        return self._extract_url_from_search_response(res["play"])
 
     def _video_matches(self, video, video_format):
         video_height = video_format[1].replace("p", "")
-        video_codec = self.settings.VIDEO_CODEC["AV1"] if self.video_av1 else \
-            self.settings.VIDEO_CODEC["H.264"]
-
-        return str(video["height"]) == video_height and video["codec"] == video_codec
+        return str(video["height"]) == video_height and video["codec"] == self._get_video_codec()
 
     def _extract_url_from_search_response(self, video_files):
         video_format = self.settings.VIDEO_FORMAT[self.video_stream]
@@ -252,14 +241,15 @@ class Api:
                     return video_file["link"]
 
             # Fallback if no matching quality was found
+            for video_file in video_files["progressive"]:
+                if video_file["codec"] == self._get_video_codec():
+                    return video_file["link"]
+
+            # Fallback if fallback failed
             return video_files["progressive"][0]["link"]
 
         else:
             raise RuntimeError("Could not extract video URL")
-
-    def _get_on_demand_trailer(self, uri):
-        res = self._do_api_request(uri, {"fields": "uri,type,play"})
-        return self._extract_url_from_search_response(res["play"])
 
     def _extract_url_from_video_config(self, video_config):
         video_files = video_config["request"]["files"]
@@ -286,6 +276,20 @@ class Api:
 
         else:
             raise RuntimeError("Could not extract video URL")
+
+    def _get_video_codec(self):
+        return self.settings.VIDEO_CODEC["AV1"] if self.video_av1 else \
+            self.settings.VIDEO_CODEC["H.264"]
+
+    def _get_default_params(self):
+        return {
+            "per_page": self.api_limit,
+            "total": self.api_limit,
+            # Avoid rate limiting:
+            # https://developer.vimeo.com/guidelines/rate-limiting#avoid-rate-limiting
+            "fields": "uri,resource_key,name,description,type,duration,created_time,location,"
+                      "bio,stats,user,account,release_time,pictures,metadata,play"
+        }
 
     @staticmethod
     def _get_picture(data, size=1):

--- a/resources/lib/vimeo/api.py
+++ b/resources/lib/vimeo/api.py
@@ -175,7 +175,6 @@ class Api:
                         "description": item["description"],
                         "duration": item["duration"],
                         "picture": self._get_picture(item["pictures"], 4),
-                        "playcount": item["stats"].get("plays", 0),
                         "user": item["user"]["name"],
                         "userThumb": self._get_picture(item["user"]["pictures"], 3),
                         "mediaUrlResolved": contains_media_url,

--- a/resources/plugin.py
+++ b/resources/plugin.py
@@ -2,13 +2,6 @@ from future import standard_library
 from future.utils import PY2
 standard_library.install_aliases()  # noqa: E402
 
-from resources.lib.vimeo.api import Api
-from resources.lib.kodi.cache import Cache
-from resources.lib.kodi.items import Items
-from resources.lib.kodi.search_history import SearchHistory
-from resources.lib.kodi.settings import Settings
-from resources.lib.kodi.vfs import VFS
-from resources.routes import *
 import os
 import sys
 import urllib.parse
@@ -16,6 +9,14 @@ import xbmc
 import xbmcaddon
 import xbmcgui
 import xbmcplugin
+
+from resources.lib.vimeo.api import Api
+from resources.lib.kodi.cache import Cache
+from resources.lib.kodi.items import Items
+from resources.lib.kodi.search_history import SearchHistory
+from resources.lib.kodi.settings import Settings
+from resources.lib.kodi.vfs import VFS
+from resources.routes import *
 
 addon = xbmcaddon.Addon()
 addon_id = addon.getAddonInfo("id")

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -15,6 +15,6 @@ if os.path.exists(build_dir):
     shutil.rmtree(build_dir)
 
 # Copy files
-shutil.copytree(".", build_dir + "/" + addon_name, False, ignore)
+shutil.copytree(".", os.path.join(build_dir, addon_name), False, ignore)
 
 print("Build finished!")

--- a/tests/mocks/api_videos_detail.json
+++ b/tests/mocks/api_videos_detail.json
@@ -3,43 +3,9 @@
     "name": "Beautiful Chaos",
     "description": "\"Chaos it said to be the opposite of order, and order, the basis for beauty. But that doesn’t mean that chaos can’t be beautiful too\"Joel Meyerowitz\n\nDirected by Fernando Livschitz\nwww.bsfilms.me\nwww.instagram.com/ferliv/\nwww.facebook.com/ferliv",
     "type": "video",
-    "link": "https://vimeo.com/352494023",
     "duration": 76,
-    "width": 3840,
-    "language": null,
-    "height": 2160,
-    "embed": {
-        "html": "<iframe src=\"https://player.vimeo.com/video/352494023?badge=0&autopause=0&player_id=0&app_id=148082\" width=\"3840\" height=\"2160\" frameborder=\"0\" title=\"Beautiful Chaos\" allow=\"autoplay; fullscreen\" allowfullscreen></iframe>",
-        "badges": {
-            "hdr": false,
-            "live": {
-                "streaming": false,
-                "archived": false
-            },
-            "staff_pick": {
-                "normal": true,
-                "best_of_the_month": false,
-                "best_of_the_year": false,
-                "premiere": false
-            },
-            "vod": false,
-            "weekend_challenge": false
-        }
-    },
     "created_time": "2019-08-07T14:20:43+00:00",
-    "modified_time": "2019-08-21T14:33:37+00:00",
     "release_time": "2019-08-07T14:20:43+00:00",
-    "content_rating": [
-        "safe"
-    ],
-    "license": null,
-    "privacy": {
-        "view": "anybody",
-        "embed": "public",
-        "download": true,
-        "add": true,
-        "comments": "anybody"
-    },
     "pictures": {
         "uri": "/videos/352494023/pictures/804395055",
         "active": true,
@@ -70,12 +36,6 @@
                 "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F804395055_640x360.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
             },
             {
-                "width": 960,
-                "height": 540,
-                "link": "https://i.vimeocdn.com/video/804395055_960x540.jpg?r=pad",
-                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F804395055_960x540.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
-            },
-            {
                 "width": 1280,
                 "height": 720,
                 "link": "https://i.vimeocdn.com/video/804395055_1280x720.jpg?r=pad",
@@ -88,119 +48,25 @@
                 "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F804395055_1920x1080.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
             },
             {
-                "width": 1280,
-                "height": 720,
-                "link": "https://i.vimeocdn.com/video/804395055_1280x720.jpg?r=pad",
-                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F804395055_1280x720.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
+                "width": 960,
+                "height": 540,
+                "link": "https://i.vimeocdn.com/video/804395055_960x540.jpg?r=pad",
+                "link_with_play_button": "https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F804395055_960x540.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png"
             }
         ],
         "resource_key": "9603ad79aaac42abe1cd6f51e2ec198716fee2ea"
     },
-    "tags": [
-        {
-            "uri": "/tags/amusementpark",
-            "name": "amusement park",
-            "tag": "amusement park",
-            "canonical": "amusementpark",
-            "metadata": {
-                "connections": {
-                    "videos": {
-                        "uri": "/tags/amusementpark/videos",
-                        "options": [
-                            "GET"
-                        ],
-                        "total": 1811
-                    }
-                }
-            },
-            "resource_key": "b94a91e158b2cfe0fa6f4b57a5a1c77b0f615c9d"
-        },
-        {
-            "uri": "/tags/newyork",
-            "name": "new york",
-            "tag": "new york",
-            "canonical": "newyork",
-            "metadata": {
-                "connections": {
-                    "videos": {
-                        "uri": "/tags/newyork/videos",
-                        "options": [
-                            "GET"
-                        ],
-                        "total": 135109
-                    }
-                }
-            },
-            "resource_key": "12f49ffa4ea1d31cb6699685d3ff9b75e258c798"
-        },
-        {
-            "uri": "/tags/rollercoaster",
-            "name": "Roller coaster",
-            "tag": "Roller coaster",
-            "canonical": "rollercoaster",
-            "metadata": {
-                "connections": {
-                    "videos": {
-                        "uri": "/tags/rollercoaster/videos",
-                        "options": [
-                            "GET"
-                        ],
-                        "total": 3957
-                    }
-                }
-            },
-            "resource_key": "839b365334c8fdb34d02dafbb4d045819109fb3a"
-        },
-        {
-            "uri": "/tags/vfx",
-            "name": "vfx",
-            "tag": "vfx",
-            "canonical": "vfx",
-            "metadata": {
-                "connections": {
-                    "videos": {
-                        "uri": "/tags/vfx/videos",
-                        "options": [
-                            "GET"
-                        ],
-                        "total": 147355
-                    }
-                }
-            },
-            "resource_key": "787d50a1441007682409e897a305cfe745192911"
-        },
-        {
-            "uri": "/tags/buenosaires",
-            "name": "buenos aires",
-            "tag": "buenos aires",
-            "canonical": "buenosaires",
-            "metadata": {
-                "connections": {
-                    "videos": {
-                        "uri": "/tags/buenosaires/videos",
-                        "options": [
-                            "GET"
-                        ],
-                        "total": 23101
-                    }
-                }
-            },
-            "resource_key": "798e0330c4d0343a3698fa50d9419fb328547217"
-        }
-    ],
     "stats": {
-        "plays": 21967
+        "plays": null
     },
-    "categories": [],
     "metadata": {
         "connections": {
             "comments": {
                 "uri": "/videos/352494023/comments",
                 "options": [
-                    "GET",
-                    "POST"
+                    "GET"
                 ],
-                "total": 26
+                "total": 37
             },
             "credits": {
                 "uri": "/videos/352494023/credits",
@@ -215,7 +81,7 @@
                 "options": [
                     "GET"
                 ],
-                "total": 417
+                "total": 1116
             },
             "pictures": {
                 "uri": "/videos/352494023/pictures",
@@ -233,66 +99,9 @@
                 ],
                 "total": 0
             },
-            "related": null,
-            "recommendations": {
-                "uri": "/videos/352494023/recommendations",
-                "options": [
-                    "GET"
-                ]
-            },
-            "albums": {
-                "uri": "/videos/352494023/albums",
-                "options": [
-                    "GET",
-                    "PATCH"
-                ],
-                "total": 3
-            },
-            "available_albums": {
-                "uri": "/videos/352494023/available_albums",
-                "options": [
-                    "GET"
-                ],
-                "total": 0
-            },
-            "available_channels": {
-                "uri": "/videos/352494023/available_channels",
-                "options": [
-                    "GET"
-                ],
-                "total": 0
-            },
-            "versions": {
-                "uri": "/videos/352494023/versions",
-                "options": [
-                    "GET"
-                ],
-                "total": 1,
-                "current_uri": "/videos/352494023/versions/248548562",
-                "resource_key": "1f7a23a8d55b85668ef915ca56eea5ddd3ed7c54"
-            }
+            "related": null
         },
         "interactions": {
-            "watchlater": {
-                "uri": "/users/3400243/watchlater/352494023",
-                "options": [
-                    "GET",
-                    "PUT",
-                    "DELETE"
-                ],
-                "added": false,
-                "added_time": null
-            },
-            "like": {
-                "uri": "/users/3400243/likes/352494023",
-                "options": [
-                    "GET",
-                    "PUT",
-                    "DELETE"
-                ],
-                "added": false,
-                "added_time": null
-            },
             "report": {
                 "uri": "/videos/352494023/report",
                 "options": [
@@ -315,6 +124,7 @@
         "name": "Black Sheep Films",
         "link": "https://vimeo.com/bsfilms",
         "location": "",
+        "gender": "m",
         "bio": null,
         "short_bio": "Film Director from Argentina, working all around the world. www.bsfilms.me",
         "created_time": "2010-06-16T16:26:57+00:00",
@@ -375,11 +185,18 @@
             {
                 "name": null,
                 "link": "https://www.bsfilms.me",
+                "type": "link",
                 "description": null
             }
         ],
         "metadata": {
             "connections": {
+                "activities": {
+                    "uri": "/users/4063790/activities",
+                    "options": [
+                        "GET"
+                    ]
+                },
                 "albums": {
                     "uri": "/users/4063790/albums",
                     "options": [
@@ -393,6 +210,13 @@
                         "GET"
                     ],
                     "total": 5
+                },
+                "categories": {
+                    "uri": "/users/4063790/categories",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 2
                 },
                 "channels": {
                     "uri": "/users/4063790/channels",
@@ -412,7 +236,7 @@
                     "options": [
                         "GET"
                     ],
-                    "total": 5731
+                    "total": 6090
                 },
                 "following": {
                     "uri": "/users/4063790/following",
@@ -426,7 +250,7 @@
                     "options": [
                         "GET"
                     ],
-                    "total": 286
+                    "total": 285
                 },
                 "likes": {
                     "uri": "/users/4063790/likes",
@@ -462,12 +286,19 @@
                     ],
                     "total": 16
                 },
+                "watchlater": {
+                    "uri": "/users/4063790/watchlater",
+                    "options": [
+                        "GET"
+                    ],
+                    "total": 12
+                },
                 "shared": {
                     "uri": "/users/4063790/shared/videos",
                     "options": [
                         "GET"
                     ],
-                    "total": 133
+                    "total": 136
                 },
                 "pictures": {
                     "uri": "/users/4063790/pictures",
@@ -477,63 +308,328 @@
                     ],
                     "total": 1
                 }
-            },
-            "interactions": {
-                "follow": {
-                    "added": false,
-                    "added_time": null,
-                    "uri": "/users/3400243/following/4063790",
-                    "options": [
-                        "GET",
-                        "PUT",
-                        "DELETE"
-                    ]
-                },
-                "block": {
-                    "uri": "/me/block/4063790",
-                    "options": [
-                        "PUT",
-                        "DELETE"
-                    ],
-                    "added": false,
-                    "added_time": null
-                },
-                "report": {
-                    "uri": "/users/4063790/report",
-                    "options": [
-                        "POST"
-                    ],
-                    "reason": [
-                        "inappropriate avatar",
-                        "spammy",
-                        "bad videos",
-                        "creepy",
-                        "not playing nice",
-                        "impersonation"
-                    ]
-                }
             }
         },
+        "location_details": {
+            "formatted_address": "",
+            "latitude": null,
+            "longitude": null,
+            "city": null,
+            "state": null,
+            "neighborhood": null,
+            "sub_locality": null,
+            "state_iso_code": null,
+            "country": null,
+            "country_iso_code": null
+        },
+        "skills": [],
+        "available_for_hire": true,
         "resource_key": "275f42c074418c49d2fe024851a403fcafd4f629",
-        "account": "pro"
+        "account": "pro",
+        "badge": {
+            "type": "pro",
+            "text": "PRO",
+            "alt_text": "Learn more about Vimeo PRO",
+            "url": "/pro"
+        },
+        "preferences": {
+            "videos": {
+                "privacy": null
+            }
+        }
     },
-    "app": {
-        "name": "Dropbox",
-        "uri": "/apps/20166"
+    "play": {
+        "progressive": [
+            {
+                "type": "video/mp4",
+                "codec": "AV1",
+                "width": 2560,
+                "height": 1440,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1446216704.mp4?GoogleAccessId=GOOGLW2TRT7BCCZZO5AX&Expires=1585526674&Signature=lRBNzCGsHGnmnyfr1CFpI5ZR2Xw%3D",
+                "created_time": "2019-08-21T20:10:29+00:00",
+                "fps": 24,
+                "size": 71766283,
+                "md5": "a50a6dfb98fe1285edf97faa4f1800c1",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1446216704",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "AV1",
+                "width": 1280,
+                "height": 720,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1446216702.mp4?GoogleAccessId=GOOGLW2TRT7BCCZZO5AX&Expires=1585526674&Signature=GE3Seulsbz4V5Ts0nhkPdGVH%2BQQ%3D",
+                "created_time": "2019-08-21T20:10:29+00:00",
+                "fps": 24,
+                "size": 22499734,
+                "md5": "37e4dc84b1a22718b01dabe5444696b4",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1446216702",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "AV1",
+                "width": 3840,
+                "height": 2160,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1446216701.mp4?GoogleAccessId=GOOGLW2TRT7BCCZZO5AX&Expires=1585526674&Signature=GSV6OaKOjFh0JS7eZiE02wJ7VBs%3D",
+                "created_time": "2019-08-21T20:10:29+00:00",
+                "fps": 24,
+                "size": 115931061,
+                "md5": "d28aaecb14fe45d090d8a658731291c2",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1446216701",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "AV1",
+                "width": 640,
+                "height": 360,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1446202911.mp4?GoogleAccessId=GOOGLW2TRT7BCCZZO5AX&Expires=1585526674&Signature=OnrsAL2Xc8xy3q5eWGIITQmhc2M%3D",
+                "created_time": "2019-08-21T20:00:09+00:00",
+                "fps": 24,
+                "size": 4633598,
+                "md5": "07ea03e89b80c228fdc50eca44e03f42",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1446202911",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "AV1",
+                "width": 1920,
+                "height": 1080,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1446202906.mp4",
+                "created_time": "2019-08-21T20:00:09+00:00",
+                "fps": 24,
+                "size": 36352691,
+                "md5": "b3e963e9f46ed2356d31105a80b6b6fd",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1446202906",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "AV1",
+                "width": 426,
+                "height": 240,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1446202902.mp4?GoogleAccessId=GOOGLW2TRT7BCCZZO5AX&Expires=1585526674&Signature=iBWJgFfdaDkH2P8%2Bi4v63kKBIdo%3D",
+                "created_time": "2019-08-21T20:00:09+00:00",
+                "fps": 24,
+                "size": 3166509,
+                "md5": "b136b0342e2cc6c2f67a307832c7c202",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1446202902",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "AV1",
+                "width": 960,
+                "height": 540,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1446202901.mp4?GoogleAccessId=GOOGLW2TRT7BCCZZO5AX&Expires=1585526674&Signature=wWltiZBMbumSXH0keui7XDvVd4Q%3D",
+                "created_time": "2019-08-21T20:00:09+00:00",
+                "fps": 24,
+                "size": 12273094,
+                "md5": "60287499a6fc1d1437c6ee148d5143af",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1446202901",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "H264",
+                "width": 3840,
+                "height": 2160,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1430794570.mp4",
+                "created_time": "2019-08-07T14:25:21+00:00",
+                "fps": 24,
+                "size": 193269109,
+                "md5": "530b516c94c434fb5218303e41c26e65",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1430794570",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "H264",
+                "width": 2560,
+                "height": 1440,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1430794562.mp4?GoogleAccessId=GOOGLW2TRT7BCCZZO5AX&Expires=1585526674&Signature=x660HQXwm9ut6iFG83PH8V3VRKE%3D",
+                "created_time": "2019-08-07T14:25:21+00:00",
+                "fps": 24,
+                "size": 100850382,
+                "md5": "eeb42a9cee9d6c9d31a6793458e61331",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1430794562",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "H264",
+                "width": 1280,
+                "height": "720 made invalid for test",
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1430794545.mp4",
+                "created_time": "2019-08-07T14:25:20+00:00",
+                "fps": 24,
+                "size": 24965674,
+                "md5": "e8c61bf0e6a9e45eeb39c2e59e9dd1ad",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1430794545",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "H264",
+                "width": 1920,
+                "height": 1080,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1430794539.mp4?GoogleAccessId=GOOGLW2TRT7BCCZZO5AX&Expires=1585526674&Signature=2FtnEL3dY0OqbK3DYgOcskgsXXY%3D",
+                "created_time": "2019-08-07T14:25:20+00:00",
+                "fps": 24,
+                "size": 47247167,
+                "md5": "5fffd7bd960450d60992138e55e27a14",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1430794539",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "H264",
+                "width": 960,
+                "height": 540,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1430794417.mp4?GoogleAccessId=GOOGLW2TRT7BCCZZO5AX&Expires=1585526674&Signature=0IWqcv2PLmNPNMcgLbWUolsuCy8%3D",
+                "created_time": "2019-08-07T14:25:17+00:00",
+                "fps": 24,
+                "size": 15382541,
+                "md5": "e1cd331a924d648f7c46d37af6f87ed6",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1430794417",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "H264",
+                "width": 640,
+                "height": 360,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1430794413.mp4",
+                "created_time": "2019-08-07T14:25:17+00:00",
+                "fps": 24,
+                "size": 5818843,
+                "md5": "52ca528cc2ca74e422e7a519a8a04784",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1430794413",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            },
+            {
+                "type": "video/mp4",
+                "codec": "H264",
+                "width": 426,
+                "height": 240,
+                "link_expiration_time": "2020-03-30T00:04:34+00:00",
+                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1430794410.mp4?GoogleAccessId=GOOGLW2TRT7BCCZZO5AX&Expires=1585526674&Signature=YpH%2Fm36x6hrQdTvQR0bIxM9ZSTs%3D",
+                "created_time": "2019-08-07T14:25:17+00:00",
+                "fps": 24,
+                "size": 3388159,
+                "md5": "1d678298cd787ac5e3061a6b28a1ddfc",
+                "log": {
+                    "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/1430794410",
+                    "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                    "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+                }
+            }
+        ],
+        "hls": {
+            "link_expiration_time": "2020-03-29T23:04:34+00:00",
+            "link": "https://player.vimeo.com/play/1446216704/hls",
+            "log": {
+                "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/hls",
+                "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+            }
+        },
+        "dash": {
+            "link_expiration_time": "2020-03-29T23:04:34+00:00",
+            "link": "https://player.vimeo.com/play/1446216704,1446216702,1446216701,1446202911,1446202906,1446202902,1446202901,1430794593,1430794587,1430794583,1430794576,1430794570,1430794564,1430794562,1430794556,1430794552,1430794545,1430794539,1430794417,1430794413,1430794410/dash?s=352494023_1585523074_2285b7ca41b48b948e4b70646911e3d2&context=Vimeo%5CController%5CApi%5CResources%5CVideoController.&logging=false",
+            "log": {
+                "play_link": "https://api.vimeo.com/videos/352494023/stats/play/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c/dash",
+                "like_press_link": "https://api.vimeo.com/videos/352494023/stats/like_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                "watchlater_press_link": "https://api.vimeo.com/videos/352494023/stats/watchlater_press/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                "load_link": "https://api.vimeo.com/videos/352494023/stats/load/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c",
+                "exit_link": "https://api.vimeo.com/videos/352494023/stats/exit/ts/1585515874:e9e53d1cb14c650327f27c11d73833bd8101952c"
+            }
+        },
+        "status": "playable"
     },
-    "status": "available",
-    "resource_key": "8f891b7c2a5be39a753f65e3fc057b83652231c7",
-    "upload": {
-        "status": "complete",
-        "link": null,
-        "upload_link": null,
-        "complete_uri": null,
-        "form": null,
-        "approach": null,
-        "size": null,
-        "redirect_url": null
-    },
-    "transcode": {
-        "status": "complete"
-    }
+    "resource_key": "8f891b7c2a5be39a753f65e3fc057b83652231c7"
 }

--- a/tests/resources/lib/vimeo/test_api.py
+++ b/tests/resources/lib/vimeo/test_api.py
@@ -1,5 +1,6 @@
 import json
 import sys
+
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock
 sys.modules["xbmc"] = MagicMock()
@@ -27,48 +28,13 @@ class ApiTestCase(TestCase):
 
         self.assertEqual(res.items[0].label, "kodi James")
         self.assertEqual(res.items[0].info["user"], "Foo User")
-        self.assertEqual(res.items[0].uri, "https://player.vimeo.com/play/23910873/hls")
+        self.assertEqual(res.items[0].uri, "/videos/13101116")
         self.assertEqual(res.items[0].thumb, "https://i.vimeocdn.com/video/74666133_200x150.jpg?r=pad")
-        self.assertEqual(res.items[0].info["mediaUrlResolved"], True)
 
         self.assertEqual(res.items[1].label, "Kodi Sings")
         self.assertEqual(res.items[1].info["user"], "Bar User")
-        self.assertEqual(res.items[1].uri, "https://player.vimeo.com/play/1352990485,1352990483,1352990478/hls")
+        self.assertEqual(res.items[1].uri, "/videos/339780805")
         self.assertEqual(res.items[1].thumb, "https://i.vimeocdn.com/video/787910745_200x150.jpg?r=pad")
-        self.assertEqual(res.items[1].info["mediaUrlResolved"], True)
-
-        self.api.video_stream = "720p"
-        res = self.api.search("foo", "videos")
-
-        self.assertEqual(res.items[0].uri, "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/2620/0/13101116/23910873.mp4")
-        self.assertEqual(res.items[0].info["mediaUrlResolved"], True)
-
-    def test_search_videos_av1(self):
-        with open("./tests/mocks/api_videos_search_av1.json") as f:
-            mock_data = f.read()
-
-        self.api._do_api_request = Mock(return_value=json.loads(mock_data))
-        self.api._hls_playlist_sanitize = Mock(return_value="/local/path")
-
-        self.api.video_av1 = False
-        self.api.video_stream = "HLS (Adaptive)"
-        res = self.api.search("foo", "bar")
-
-        self.assertEqual(res.items[0].label, "The Pet Files")
-        self.assertEqual(res.items[0].uri, "https://player.vimeo.com/play/1666570518,1666570517,1666570516,1666570515,1666570514,1663613697,1663613671,1663613568,1663612618,1663612616/hls?")
-        self.assertEqual(res.items[0].info["mediaUrlResolved"], True)
-
-        self.api.video_stream = "1080p"
-        res = self.api.search("foo", "bar")
-
-        self.assertEqual(res.items[0].label, "The Pet Files")
-        self.assertEqual(res.items[0].uri, "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/3508/15/392544832/1663613697.mp4")
-
-        self.api.video_av1 = True
-        res = self.api.search("foo", "bar")
-
-        self.assertEqual(res.items[0].label, "The Pet Files")
-        self.assertEqual(res.items[0].uri, "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/3508/15/392544832/1666570518.mp4")
 
     def test_search_videos_no_media_urls(self):
         with open("./tests/mocks/api_videos_search_fallback.json") as f:
@@ -79,7 +45,6 @@ class ApiTestCase(TestCase):
         res = self.api.search("foo", "videos")
 
         self.assertEqual(res.items[0].uri, "/videos/13101116")
-        self.assertEqual(res.items[0].info["mediaUrlResolved"], False)
 
     def test_search_videos_on_demand(self):
         with open("./tests/mocks/api_videos_search_on_demand.json") as f:
@@ -89,28 +54,14 @@ class ApiTestCase(TestCase):
         self.api.video_stream = "HLS (Adaptive)"
         res = self.api.search("foo", "videos")
 
-        self.assertEqual(res.items[0].uri, "https://player.vimeo.com/play/1546650582/hls")
-        self.assertEqual(res.items[0].info["mediaUrlResolved"], True)
+        self.assertEqual(res.items[0].uri, "/videos/372251058")
         self.assertEqual(res.items[0].info["onDemand"], False)
 
         self.assertEqual(res.items[1].uri, "/ondemand/pages/25096/videos/97663163")
-        self.assertEqual(res.items[1].info["mediaUrlResolved"], False)
         self.assertEqual(res.items[1].info["onDemand"], True)
 
-        self.assertEqual(res.items[2].uri, "https://player.vimeo.com/play/120186138/hls")
-        self.assertEqual(res.items[2].info["mediaUrlResolved"], True)
+        self.assertEqual(res.items[2].uri, "/videos/31158028")
         self.assertEqual(res.items[2].info["onDemand"], False)
-
-    def test_search_videos_no_hls(self):
-        with open("./tests/mocks/api_videos_search_no_hls.json") as f:
-            mock_data = f.read()
-
-        self.api._do_api_request = Mock(return_value=json.loads(mock_data))
-        self.api.video_stream = "HLS (Adaptive)"
-        res = self.api.search("foo", "videos")
-
-        self.assertEqual(res.items[0].label, "Zygote Balls at BIP, Florence, Italy")
-        self.assertEqual(res.items[0].uri, "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/54/0/270719/15090045.mp4")
 
     def test_search_users(self):
         with open("./tests/mocks/api_users_search.json") as f:
@@ -169,20 +120,11 @@ class ApiTestCase(TestCase):
         self.api._do_api_request = Mock(return_value=json.loads(mock_data))
         self.api.video_stream = "720p"
 
-        self.api.video_av1 = False
         res = self.api.channel("1")
 
         self.assertEqual(res.items[0].label, "The Pet Files")
         self.assertEqual(res.items[0].thumb, "https://i.vimeocdn.com/video/857679735_200x150.jpg?r=pad")
-        self.assertEqual(res.items[0].uri, "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/3508/15/392544832/1663613568.mp4")
-        self.assertEqual(res.items[0].info["mediaUrlResolved"], True)
-
-        self.api.video_av1 = True
-        res = self.api.channel("1")
-
-        self.assertEqual(res.items[0].label, "The Pet Files")
-        self.assertEqual(res.items[0].thumb, "https://i.vimeocdn.com/video/857679735_200x150.jpg?r=pad")
-        self.assertEqual(res.items[0].uri, "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/3508/15/392544832/1666570517.mp4")
+        self.assertEqual(res.items[0].uri, "/videos/392544832")
 
     def test_resolve_id(self):
         with open("./tests/mocks/api_videos_detail.json") as f:
@@ -197,8 +139,35 @@ class ApiTestCase(TestCase):
         self.assertEqual(res.items[0].uri, "/videos/352494023")
 
     def test_resolve_media_url(self):
-        res = self.api.resolve_media_url("https://player.vimeo.com/play/1663612616/hls?123")
-        self.assertEqual(res, "https://player.vimeo.com/play/1663612616/hls?123")
+        with open("./tests/mocks/api_videos_detail.json") as f:
+            mock_data = f.read()
+
+        # Progressive
+        self.api.video_av1 = False
+        self.api.video_stream = "360p"
+        self.api._do_api_request = Mock(return_value=json.loads(mock_data))
+        res = self.api.resolve_media_url("/videos/352494023")
+        self.assertEqual(res, "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1430794413.mp4")
+
+        # Progressive (AV1)
+        self.api.video_av1 = True
+        self.api.video_stream = "1080p"
+        self.api._do_api_request = Mock(return_value=json.loads(mock_data))
+        res = self.api.resolve_media_url("/videos/352494023")
+        self.assertEqual(res, "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1446202906.mp4")
+
+        # Progressive (fallback)
+        self.api.video_av1 = False
+        self.api.video_stream = "720p"  # Resolution does not exist in API response
+        self.api._do_api_request = Mock(return_value=json.loads(mock_data))
+        res = self.api.resolve_media_url("/videos/352494023")
+        self.assertEqual(res, "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1430794570.mp4")
+
+        # HLS stream
+        self.api.video_stream = "HLS (Adaptive)"
+        self.api._do_api_request = Mock(return_value=json.loads(mock_data))
+        res = self.api.resolve_media_url("/videos/352494023")
+        self.assertEqual(res, "https://player.vimeo.com/play/1446216704/hls")
 
     def test_resolve_media_url_on_demand(self):
         with open("./tests/mocks/api_ondemand_video.json") as f:
@@ -214,6 +183,7 @@ class ApiTestCase(TestCase):
         with open("./tests/mocks/player_video_config.json") as f:
             mock_data = f.read()
 
+        self.api.api_fallback = True
         self.api.video_av1 = False
 
         # Progressive
@@ -233,7 +203,7 @@ class ApiTestCase(TestCase):
 
         self.api.video_av1 = False
 
-        # HLS stream (AV1)
+        # HLS stream
         self.api.video_stream = "HLS (Adaptive)"
         self.api._do_player_request = Mock(return_value=json.loads(mock_data))
         res = self.api.resolve_media_url("/videos/13101116")


### PR DESCRIPTION
Since using the new endpoint for video URLs, videos were not
marked as watched anymore. This is because the video URLs were
now containing the direct media links. But they are not unique,
because they contain information that changes on every request.
By using video URI as URL again, we get unique URLs again.

Also fixed a bug were the resolution-not-found fallback
would fall back to AV1 codec instead of H264.