### PR TITLE
Overwrite macOS user-agent when requesting videos

### DIFF
--- a/tests/mocks/api_videos_detail.json
+++ b/tests/mocks/api_videos_detail.json
@@ -536,7 +536,7 @@
                 "width": 1920,
                 "height": 1080,
                 "link_expiration_time": "2020-03-30T00:04:34+00:00",
-                "link": "https://vimeo-prod-skyfire-std-us.storage.googleapis.com/01/498/14/352494023/1430794539.mp4?GoogleAccessId=GOOGLW2TRT7BCCZZO5AX&Expires=1585526674&Signature=2FtnEL3dY0OqbK3DYgOcskgsXXY%3D",
+                "link": "http://a.b/c.mp4",
                 "created_time": "2019-08-07T14:25:20+00:00",
                 "fps": 24,
                 "size": 47247167,

--- a/tests/resources/lib/vimeo/test_api.py
+++ b/tests/resources/lib/vimeo/test_api.py
@@ -3,7 +3,7 @@ import sys
 
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock
-sys.modules["xbmc"] = MagicMock()
+sys.modules["xbmc"] = xbmcMock = MagicMock()
 sys.modules["xbmcaddon"] = MagicMock()
 sys.modules["xbmcgui"] = MagicMock()
 from resources.lib.kodi.settings import Settings
@@ -15,6 +15,7 @@ class ApiTestCase(TestCase):
     def setUp(self):
         self.api = Api(Settings(MagicMock()), "en", MagicMock(), MagicMock())
         self.api.api_cdn = "fastly_skyfire"
+        xbmcMock.getUserAgent = Mock(return_value="A User-Agent String")
 
     def test_search_videos(self):
         with open("./tests/mocks/api_videos_search.json") as f:
@@ -248,3 +249,14 @@ class ApiTestCase(TestCase):
         self.api._do_player_request = Mock(return_value=json.loads(mock_data))
         res = self.api.resolve_media_url("/videos/13101116")
         self.assertEqual(res, "https://skyfire.vimeocdn.com/av1")
+
+    def test_resolve_media_url_macos(self):
+        with open("./tests/mocks/api_videos_detail.json") as f:
+            mock_data = f.read()
+
+        xbmcMock.getUserAgent = Mock(return_value="A Mac OS X User Agent")
+
+        self.api.video_stream = "1080p"
+        self.api._do_api_request = Mock(return_value=json.loads(mock_data))
+        res = self.api.resolve_media_url("/videos/123")
+        self.assertEqual(res, "http://a.b/c.mp4|User-Agent=pyvimeo%201.0.11%3B%20%28http%3A//developer.vimeo.com/api/docs%29")


### PR DESCRIPTION
Kodi automatically uses a operating system based User-Agent
for HTTP requests. This causes an issue with the Vimeo API
endpoint when a request is made from macOS, because the
Vimeo endpoint then thinks it can deliver the DASH format
to an iOS device. This DASH format can currently not be
played by ffmpeg. By appending a custom User-Agent at the
end of the URL, the User-Agent can be overwritten.

Fixes #31