### PR TITLE
Fix direct playing of live videos

### DIFF
--- a/resources/lib/vimeo/api.py
+++ b/resources/lib/vimeo/api.py
@@ -172,7 +172,7 @@ class Api:
         collection.items = []  # Reset list in order to resolve problems in unit tests
         collection.next_href = json_obj.get("paging", {"next": None})["next"]
 
-        if "type" in json_obj and json_obj["type"] == "video":
+        if "type" in json_obj and json_obj["type"] in ("video", "live"):
             # If we are dealing with a single video, pack it into a dict
             json_obj = {"data": [json_obj]}
 

--- a/tests/resources/lib/vimeo/test_api.py
+++ b/tests/resources/lib/vimeo/test_api.py
@@ -184,6 +184,17 @@ class ApiTestCase(TestCase):
         self.assertEqual(res.items[0].thumb, "https://i.vimeocdn.com/video/804395055_200x150.jpg?r=pad")
         self.assertEqual(res.items[0].uri, "/videos/352494023")
 
+        with open("./tests/mocks/api_videos_detail_live.json") as f:
+            mock_data = f.read()
+
+        self.api._do_api_request = Mock(return_value=json.loads(mock_data))
+
+        res = self.api.resolve_id("401749070")
+
+        self.assertEqual(res.items[0].label, "Vespers & Benediction: 6PM (CT)")
+        self.assertEqual(res.items[0].thumb, "https://i.vimeocdn.com/video/default-live_200x150?r=pad")
+        self.assertEqual(res.items[0].uri, "/videos/401749070")
+
     def test_resolve_media_url(self):
         with open("./tests/mocks/api_videos_detail.json") as f:
             mock_data = f.read()


### PR DESCRIPTION
When sharing a video via ID, live videos couldn't be resolved correctly.

Fixes #40