### PR TITLE
Don't add video to playlist when shared

### DIFF
--- a/resources/plugin.py
+++ b/resources/plugin.py
@@ -108,9 +108,7 @@ def run():
                         xbmcgui.NOTIFICATION_ERROR
                     )
 
-            playlist = xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
             resolve_list_item(handle, collection[0][1], password, fetch_subtitles)
-            playlist.add(url=collection[0][0], listitem=collection[0][1])
         else:
             xbmc.log(addon_id + ": Invalid play param", xbmc.LOGERROR)
 


### PR DESCRIPTION
When a video is shared with this addon, it can be done by calling `Playlist.Add` or `Player.Open`.

If it is done via `Playlist.Add`, the item is already in a playlist, so we don't have to do it ourselves.
If it is done via `Player.Open`, the user probably doesn't want to create a playlist at all.

Resolves #66