### PR TITLE
Handle geo-blocking errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ kodistubs = "~=19.0.2"
 pycodestyle = "*"
 
 [packages]
-requests = "~=2.22.0"
+requests = "~=2.29.0"
 
 [requires]
 python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ba9e9a83d6ee778b402bd88a4953dcbe7bc29f586f4fa5c21467a5739013e8cf"
+            "sha256": "30478ec28c8f30b7717e3668b06d6a1760f978e2d43a79f8e8c294aefddf28e4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,40 +18,134 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
-                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+                "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651",
+                "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"
             ],
-            "version": "==2021.5.30"
+            "markers": "python_version >= '3.6'",
+            "version": "==2025.1.31"
         },
-        "chardet": {
+        "charset-normalizer": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0167ddc8ab6508fe81860a57dd472b2ef4060e8d378f0cc555707126830f2537",
+                "sha256:01732659ba9b5b873fc117534143e4feefecf3b2078b0a6a2e925271bb6f4cfa",
+                "sha256:01ad647cdd609225c5350561d084b42ddf732f4eeefe6e678765636791e78b9a",
+                "sha256:04432ad9479fa40ec0f387795ddad4437a2b50417c69fa275e212933519ff294",
+                "sha256:0907f11d019260cdc3f94fbdb23ff9125f6b5d1039b76003b5b0ac9d6a6c9d5b",
+                "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd",
+                "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601",
+                "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd",
+                "sha256:0af291f4fe114be0280cdd29d533696a77b5b49cfde5467176ecab32353395c4",
+                "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d",
+                "sha256:1a2bc9f351a75ef49d664206d51f8e5ede9da246602dc2d2726837620ea034b2",
+                "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313",
+                "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd",
+                "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa",
+                "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8",
+                "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1",
+                "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2",
+                "sha256:2a75d49014d118e4198bcee5ee0a6f25856b29b12dbf7cd012791f8a6cc5c496",
+                "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d",
+                "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b",
+                "sha256:2fb9bd477fdea8684f78791a6de97a953c51831ee2981f8e4f583ff3b9d9687e",
+                "sha256:311f30128d7d333eebd7896965bfcfbd0065f1716ec92bd5638d7748eb6f936a",
+                "sha256:329ce159e82018d646c7ac45b01a430369d526569ec08516081727a20e9e4af4",
+                "sha256:345b0426edd4e18138d6528aed636de7a9ed169b4aaf9d61a8c19e39d26838ca",
+                "sha256:363e2f92b0f0174b2f8238240a1a30142e3db7b957a5dd5689b0e75fb717cc78",
+                "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408",
+                "sha256:3bed14e9c89dcb10e8f3a29f9ccac4955aebe93c71ae803af79265c9ca5644c5",
+                "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3",
+                "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f",
+                "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a",
+                "sha256:49402233c892a461407c512a19435d1ce275543138294f7ef013f0b63d5d3765",
+                "sha256:4c0907b1928a36d5a998d72d64d8eaa7244989f7aaaf947500d3a800c83a3fd6",
+                "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146",
+                "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6",
+                "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9",
+                "sha256:619a609aa74ae43d90ed2e89bdd784765de0a25ca761b93e196d938b8fd1dbbd",
+                "sha256:6e27f48bcd0957c6d4cb9d6fa6b61d192d0b13d5ef563e5f2ae35feafc0d179c",
+                "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f",
+                "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545",
+                "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176",
+                "sha256:75832c08354f595c760a804588b9357d34ec00ba1c940c15e31e96d902093770",
+                "sha256:7709f51f5f7c853f0fb938bcd3bc59cdfdc5203635ffd18bf354f6967ea0f824",
+                "sha256:78baa6d91634dfb69ec52a463534bc0df05dbd546209b79a3880a34487f4b84f",
+                "sha256:7974a0b5ecd505609e3b19742b60cee7aa2aa2fb3151bc917e6e2646d7667dcf",
+                "sha256:7a4f97a081603d2050bfaffdefa5b02a9ec823f8348a572e39032caa8404a487",
+                "sha256:7b1bef6280950ee6c177b326508f86cad7ad4dff12454483b51d8b7d673a2c5d",
+                "sha256:7d053096f67cd1241601111b698f5cad775f97ab25d81567d3f59219b5f1adbd",
+                "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b",
+                "sha256:807f52c1f798eef6cf26beb819eeb8819b1622ddfeef9d0977a8502d4db6d534",
+                "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f",
+                "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b",
+                "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9",
+                "sha256:89149166622f4db9b4b6a449256291dc87a99ee53151c74cbd82a53c8c2f6ccd",
+                "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125",
+                "sha256:8c60ca7339acd497a55b0ea5d506b2a2612afb2826560416f6894e8b5770d4a9",
+                "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de",
+                "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11",
+                "sha256:97f68b8d6831127e4787ad15e6757232e14e12060bec17091b85eb1486b91d8d",
+                "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35",
+                "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f",
+                "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda",
+                "sha256:ab36c8eb7e454e34e60eb55ca5d241a5d18b2c6244f6827a30e451c42410b5f7",
+                "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a",
+                "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971",
+                "sha256:b7b2d86dd06bfc2ade3312a83a5c364c7ec2e3498f8734282c6c3d4b07b346b8",
+                "sha256:b97e690a2118911e39b4042088092771b4ae3fc3aa86518f84b8cf6888dbdb41",
+                "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d",
+                "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f",
+                "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757",
+                "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a",
+                "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886",
+                "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77",
+                "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76",
+                "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247",
+                "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85",
+                "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb",
+                "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7",
+                "sha256:dccbe65bd2f7f7ec22c4ff99ed56faa1e9f785482b9bbd7c717e26fd723a1d1e",
+                "sha256:dd78cfcda14a1ef52584dbb008f7ac81c1328c0f58184bf9a84c49c605002da6",
+                "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037",
+                "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1",
+                "sha256:ea0d8d539afa5eb2728aa1932a988a9a7af94f18582ffae4bc10b3fbdad0626e",
+                "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807",
+                "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407",
+                "sha256:ecddf25bee22fe4fe3737a399d0d177d72bc22be6913acfab364b40bce1ba83c",
+                "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12",
+                "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3",
+                "sha256:f30bf9fd9be89ecb2360c7d94a711f00c09b976258846efe40db3d05828e8089",
+                "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd",
+                "sha256:fc54db6c8593ef7d4b2a331b58653356cf04f67c960f584edb7c3d8c97e8f39e",
+                "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00",
+                "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.1"
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+                "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
             ],
-            "version": "==2.8"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.10"
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:e8f3c9be120d3333921d213eef078af392fba3933ab7ed2d1cba3b56f2568c3b",
+                "sha256:f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059"
             ],
             "index": "pypi",
-            "version": "==2.22.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.29.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
-                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
+                "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
+                "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.25.11"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.20"
         }
     },
     "develop": {
@@ -61,15 +155,17 @@
                 "sha256:d6f3379712fa944704dbb74e49b64fbc32ecc8dbfb5433221f4115e927f5b318"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==19.0.3"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068",
-                "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"
+                "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3",
+                "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"
             ],
             "index": "pypi",
-            "version": "==2.7.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.12.1"
         }
     }
 }

--- a/addon.xml
+++ b/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vimeo" name="Vimeo" version="6.0.1" provider-name="jaylinski">
+<addon id="plugin.video.vimeo" name="Vimeo" version="6.0.2" provider-name="jaylinski">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
-        <import addon="script.module.requests" version="2.22.0"/>
+        <import addon="script.module.requests" version="2.29.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon.py">
         <provides>video</provides>
@@ -16,7 +16,10 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=220437</forum>
         <website>https://vimeo.com</website>
         <source>https://github.com/jaylinski/kodi-addon-vimeo</source>
-        <news>6.0.1 (2022-02-25)
+        <news>6.0.2 (2025-02-06)
+Handle Vimeo geo-blocking by displaying an error to affected users
+
+6.0.1 (2022-02-25)
 Fixed subtitle conversion issue
 Fixed playback issue on certain videos when using HLS video format (related to AV1 codec)
 Replaced invalid video-format "240p" in settings

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -270,3 +270,11 @@ msgstr "Ungültiges Passwort"
 msgctxt "#30906"
 msgid "Whoops! That password is invalid"
 msgstr "Whoops! Dieses Passwort ist ungültig"
+
+msgctxt "#30907"
+msgid "Error"
+msgstr "Fehler"
+
+msgctxt "#30908"
+msgid "This resource is restricted in your region."
+msgstr "Diese Anfrage ist in deiner Region nicht verfügbar."

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -270,3 +270,11 @@ msgstr ""
 msgctxt "#30906"
 msgid "Whoops! That password is invalid"
 msgstr ""
+
+msgctxt "#30907"
+msgid "Error"
+msgstr ""
+
+msgctxt "#30908"
+msgid "This resource is restricted in your region."
+msgstr ""

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -211,6 +211,9 @@ class Api:
         if self._request_was_bad(json_obj) == 2222:
             raise WrongPasswordException()
 
+        if "error_code" in json_obj and json_obj["error_code"] == 5451:
+            raise ResourceRestrictedException()
+
         if "type" in json_obj and json_obj["type"] in ("video", "live"):
             # If we are dealing with a single video, pack it into a dict
             json_obj = {"data": [json_obj]}
@@ -441,4 +444,8 @@ class PasswordRequiredException(Exception):
 
 
 class WrongPasswordException(Exception):
+    pass
+
+
+class ResourceRestrictedException(Exception):
     pass

--- a/resources/plugin.py
+++ b/resources/plugin.py
@@ -7,7 +7,8 @@ import xbmcgui
 import xbmcplugin
 import xbmcvfs
 
-from resources.lib.api import Api, PasswordRequiredException, WrongPasswordException
+from resources.lib.api import Api, PasswordRequiredException, ResourceRestrictedException, \
+    WrongPasswordException
 from resources.lib.kodi.cache import Cache
 from resources.lib.kodi.items import Items
 from resources.lib.kodi.search_history import SearchHistory
@@ -37,173 +38,180 @@ def run():
     args = urllib.parse.parse_qs(sys.argv[2][1:])
     xbmcplugin.setContent(handle, "videos")
 
-    if path == PATH_ROOT:
-        action = args.get("action", None)
-        if action is None:
-            items = listItems.root()
-            xbmcplugin.addDirectoryItems(handle, items, len(items))
-            xbmcplugin.endOfDirectory(handle)
-        elif "call" in action:
-            collection = listItems.from_collection(api.call(args.get("call")[0]))
-            xbmcplugin.addDirectoryItems(handle, collection, len(collection))
-            xbmcplugin.endOfDirectory(handle)
-        elif "settings" in action:
-            addon.openSettings()
-        else:
-            xbmc.log(addon_id + ": Invalid root action", xbmc.LOGERROR)
-
-    elif path == PATH_CATEGORIES:
-        collection = listItems.from_collection(api.categories())
-        xbmcplugin.addDirectoryItems(handle, collection, len(collection))
-        xbmcplugin.endOfDirectory(handle)
-
-    elif path == PATH_TRENDING:
-        collection = listItems.from_collection(api.trending())
-        xbmcplugin.addDirectoryItems(handle, collection, len(collection))
-        xbmcplugin.endOfDirectory(handle)
-
-    elif path == PATH_FEATURED:
-        action = args.get("action", None)
-        if action is None:
-            items = listItems.featured()
-            xbmcplugin.addDirectoryItems(handle, items, len(items))
-            xbmcplugin.endOfDirectory(handle)
-        elif "channel" in action:
-            channel_id = args.get("id", [""])[0]
-            collection = listItems.from_collection(api.channel(channel_id))
-            xbmcplugin.addDirectoryItems(handle, collection, len(collection))
-            xbmcplugin.endOfDirectory(handle)
-        else:
-            xbmc.log(addon_id + ": Invalid featured action", xbmc.LOGERROR)
-
-    elif path == PATH_PLAY:
-        # Public params
-        video_id = args.get("video_id", [None])[0]
-
-        # Private params
-        media_url = args.get("uri", [None])[0]
-        texttracks = args.get("texttracks", [False])[0]
-
-        # Settings
-        fetch_subtitles = True if settings.get("video.subtitles") == "true" else False
-
-        if media_url:
-            resolved_url = api.resolve_media_url(media_url)
-            item = xbmcgui.ListItem(path=resolved_url)
-            if fetch_subtitles and texttracks:
-                item = add_subtitles(item, texttracks)
-            xbmcplugin.setResolvedUrl(handle, succeeded=True, listitem=item)
-        elif video_id:
-            try:
-                password = None
-                collection = listItems.from_collection(api.resolve_id(video_id, password))
-            except PasswordRequiredException:
-                try:
-                    password = xbmcgui.Dialog().input(addon.getLocalizedString(30904))
-                    collection = listItems.from_collection(api.resolve_id(video_id, password))
-                except WrongPasswordException:
-                    return xbmcgui.Dialog().notification(
-                        addon.getLocalizedString(30905),
-                        addon.getLocalizedString(30906),
-                        xbmcgui.NOTIFICATION_ERROR
-                    )
-
-            resolve_list_item(handle, collection[0][1], password, fetch_subtitles)
-        else:
-            xbmc.log(addon_id + ": Invalid play param", xbmc.LOGERROR)
-
-    elif path == PATH_SEARCH:
-        action = args.get("action", None)
-        query = args.get("query", [""])[0]
-
-        if action and "remove" in action:
-            search_history.remove(query)
-            xbmc.executebuiltin("Container.Refresh")
-        elif action and "clear" in action:
-            search_history.clear()
-            xbmc.executebuiltin("Container.Refresh")
-
-        if query:
+    try:
+        if path == PATH_ROOT:
+            action = args.get("action", None)
             if action is None:
-                search(handle, query)
-            elif "people" in action:
-                xbmcplugin.setContent(handle, "artists")
-                collection = listItems.from_collection(api.search(query, "users"))
-                xbmcplugin.addDirectoryItems(handle, collection, len(collection))
-                xbmcplugin.endOfDirectory(handle)
-            elif "channels" in action:
-                xbmcplugin.setContent(handle, "albums")
-                collection = listItems.from_collection(api.search(query, "channels"))
-                xbmcplugin.addDirectoryItems(handle, collection, len(collection))
-                xbmcplugin.endOfDirectory(handle)
-            elif "groups" in action:
-                xbmcplugin.setContent(handle, "albums")
-                collection = listItems.from_collection(api.search(query, "groups"))
-                xbmcplugin.addDirectoryItems(handle, collection, len(collection))
-                xbmcplugin.endOfDirectory(handle)
-            else:
-                xbmc.log(addon_id + ": Invalid search action", xbmc.LOGERROR)
-        else:
-            if action is None:
-                # Search root
-                items = listItems.search()
+                items = listItems.root()
                 xbmcplugin.addDirectoryItems(handle, items, len(items))
                 xbmcplugin.endOfDirectory(handle)
-            elif "new" in action:
-                # New search
-                query = xbmcgui.Dialog().input(addon.getLocalizedString(30101))
-                search_history.add(query)
-                search(handle, query)
+            elif "call" in action:
+                collection = listItems.from_collection(api.call(args.get("call")[0]))
+                xbmcplugin.addDirectoryItems(handle, collection, len(collection))
+                xbmcplugin.endOfDirectory(handle)
+            elif "settings" in action:
+                addon.openSettings()
             else:
-                xbmc.log(addon_id + ": Invalid search action", xbmc.LOGERROR)
+                xbmc.log(addon_id + ": Invalid root action", xbmc.LOGERROR)
 
-    elif path == PATH_AUTH_LOGIN:
-        logout()  # Make sure there is no cached access-token
-
-        device_code_response = api.oauth_device()
-        activate_link = device_code_response["activate_link"]
-        device_code = device_code_response["device_code"]
-        user_code = device_code_response["user_code"]
-        xbmcgui.Dialog().ok(
-            heading=addon.getLocalizedString(30151),
-            message="{}\n{}\n{}\n{}".format(
-                addon.getLocalizedString(30152).format(format_bold(activate_link)),
-                addon.getLocalizedString(30153).format(format_bold(user_code)),
-                addon.getLocalizedString(30154).format(format_bold(user_code)),
-                addon.getLocalizedString(30155).format(format_bold("OK")),
-            ),
-        )
-
-        user_name = api.oauth_device_authorize(user_code, device_code)
-        xbmcgui.Dialog().ok(
-            heading=addon.getLocalizedString(30151),
-            message=addon.getLocalizedString(30156).format(user_name),
-        )
-        xbmc.executebuiltin("Container.Refresh")
-
-    elif path == PATH_AUTH_LOGOUT:
-        logout()
-        xbmc.executebuiltin("Container.Refresh")
-
-    elif path == PATH_PROFILE:
-        uri = args.get("uri", [""])[0]
-
-        if uri:
-            user = api.user(uri)
-            profile_options = listItems.profile_sub(user)
-            collection = listItems.from_collection(api.call("{}/videos".format(uri)))
-            xbmcplugin.addDirectoryItems(handle, profile_options)
+        elif path == PATH_CATEGORIES:
+            collection = listItems.from_collection(api.categories())
             xbmcplugin.addDirectoryItems(handle, collection, len(collection))
             xbmcplugin.endOfDirectory(handle)
+
+        elif path == PATH_TRENDING:
+            collection = listItems.from_collection(api.trending())
+            xbmcplugin.addDirectoryItems(handle, collection, len(collection))
+            xbmcplugin.endOfDirectory(handle)
+
+        elif path == PATH_FEATURED:
+            action = args.get("action", None)
+            if action is None:
+                items = listItems.featured()
+                xbmcplugin.addDirectoryItems(handle, items, len(items))
+                xbmcplugin.endOfDirectory(handle)
+            elif "channel" in action:
+                channel_id = args.get("id", [""])[0]
+                collection = listItems.from_collection(api.channel(channel_id))
+                xbmcplugin.addDirectoryItems(handle, collection, len(collection))
+                xbmcplugin.endOfDirectory(handle)
+            else:
+                xbmc.log(addon_id + ": Invalid featured action", xbmc.LOGERROR)
+
+        elif path == PATH_PLAY:
+            # Public params
+            video_id = args.get("video_id", [None])[0]
+
+            # Private params
+            media_url = args.get("uri", [None])[0]
+            texttracks = args.get("texttracks", [False])[0]
+
+            # Settings
+            fetch_subtitles = True if settings.get("video.subtitles") == "true" else False
+
+            if media_url:
+                resolved_url = api.resolve_media_url(media_url)
+                item = xbmcgui.ListItem(path=resolved_url)
+                if fetch_subtitles and texttracks:
+                    item = add_subtitles(item, texttracks)
+                xbmcplugin.setResolvedUrl(handle, succeeded=True, listitem=item)
+            elif video_id:
+                try:
+                    password = None
+                    collection = listItems.from_collection(api.resolve_id(video_id, password))
+                except PasswordRequiredException:
+                    try:
+                        password = xbmcgui.Dialog().input(addon.getLocalizedString(30904))
+                        collection = listItems.from_collection(api.resolve_id(video_id, password))
+                    except WrongPasswordException:
+                        return xbmcgui.Dialog().notification(
+                            addon.getLocalizedString(30905),
+                            addon.getLocalizedString(30906),
+                            xbmcgui.NOTIFICATION_ERROR
+                        )
+
+                resolve_list_item(handle, collection[0][1], password, fetch_subtitles)
+            else:
+                xbmc.log(addon_id + ": Invalid play param", xbmc.LOGERROR)
+
+        elif path == PATH_SEARCH:
+            action = args.get("action", None)
+            query = args.get("query", [""])[0]
+
+            if action and "remove" in action:
+                search_history.remove(query)
+                xbmc.executebuiltin("Container.Refresh")
+            elif action and "clear" in action:
+                search_history.clear()
+                xbmc.executebuiltin("Container.Refresh")
+
+            if query:
+                if action is None:
+                    search(handle, query)
+                elif "people" in action:
+                    xbmcplugin.setContent(handle, "artists")
+                    collection = listItems.from_collection(api.search(query, "users"))
+                    xbmcplugin.addDirectoryItems(handle, collection, len(collection))
+                    xbmcplugin.endOfDirectory(handle)
+                elif "channels" in action:
+                    xbmcplugin.setContent(handle, "albums")
+                    collection = listItems.from_collection(api.search(query, "channels"))
+                    xbmcplugin.addDirectoryItems(handle, collection, len(collection))
+                    xbmcplugin.endOfDirectory(handle)
+                elif "groups" in action:
+                    xbmcplugin.setContent(handle, "albums")
+                    collection = listItems.from_collection(api.search(query, "groups"))
+                    xbmcplugin.addDirectoryItems(handle, collection, len(collection))
+                    xbmcplugin.endOfDirectory(handle)
+                else:
+                    xbmc.log(addon_id + ": Invalid search action", xbmc.LOGERROR)
+            else:
+                if action is None:
+                    # Search root
+                    items = listItems.search()
+                    xbmcplugin.addDirectoryItems(handle, items, len(items))
+                    xbmcplugin.endOfDirectory(handle)
+                elif "new" in action:
+                    # New search
+                    query = xbmcgui.Dialog().input(addon.getLocalizedString(30101))
+                    search_history.add(query)
+                    search(handle, query)
+                else:
+                    xbmc.log(addon_id + ": Invalid search action", xbmc.LOGERROR)
+
+        elif path == PATH_AUTH_LOGIN:
+            logout()  # Make sure there is no cached access-token
+
+            device_code_response = api.oauth_device()
+            activate_link = device_code_response["activate_link"]
+            device_code = device_code_response["device_code"]
+            user_code = device_code_response["user_code"]
+            xbmcgui.Dialog().ok(
+                heading=addon.getLocalizedString(30151),
+                message="{}\n{}\n{}\n{}".format(
+                    addon.getLocalizedString(30152).format(format_bold(activate_link)),
+                    addon.getLocalizedString(30153).format(format_bold(user_code)),
+                    addon.getLocalizedString(30154).format(format_bold(user_code)),
+                    addon.getLocalizedString(30155).format(format_bold("OK")),
+                ),
+            )
+
+            user_name = api.oauth_device_authorize(user_code, device_code)
+            xbmcgui.Dialog().ok(
+                heading=addon.getLocalizedString(30151),
+                message=addon.getLocalizedString(30156).format(user_name),
+            )
+            xbmc.executebuiltin("Container.Refresh")
+
+        elif path == PATH_AUTH_LOGOUT:
+            logout()
+            xbmc.executebuiltin("Container.Refresh")
+
+        elif path == PATH_PROFILE:
+            uri = args.get("uri", [""])[0]
+
+            if uri:
+                user = api.user(uri)
+                profile_options = listItems.profile_sub(user)
+                collection = listItems.from_collection(api.call("{}/videos".format(uri)))
+                xbmcplugin.addDirectoryItems(handle, profile_options)
+                xbmcplugin.addDirectoryItems(handle, collection, len(collection))
+                xbmcplugin.endOfDirectory(handle)
+            else:
+                xbmc.log(addon_id + ": Invalid profile uri", xbmc.LOGERROR)
+
+        elif path == PATH_SETTINGS_CACHE_CLEAR:
+            vfs_cache.destroy()
+            xbmcgui.Dialog().ok("Vimeo", addon.getLocalizedString(30501))
+
         else:
-            xbmc.log(addon_id + ": Invalid profile uri", xbmc.LOGERROR)
-
-    elif path == PATH_SETTINGS_CACHE_CLEAR:
-        vfs_cache.destroy()
-        xbmcgui.Dialog().ok("Vimeo", addon.getLocalizedString(30501))
-
-    else:
-        xbmc.log(addon_id + ": Path not found", xbmc.LOGERROR)
+            xbmc.log(addon_id + ": Path not found", xbmc.LOGERROR)
+    except ResourceRestrictedException:
+        return xbmcgui.Dialog().notification(
+            addon.getLocalizedString(30907),
+            addon.getLocalizedString(30908),
+            xbmcgui.NOTIFICATION_ERROR
+        )
 
 
 def resolve_list_item(handle, list_item, password=None, fetch_subtitles=False):

--- a/tests/mocks/api_geo_block.json
+++ b/tests/mocks/api_geo_block.json
@@ -1,0 +1,6 @@
+{
+  "error": "This resource is restricted in your region.",
+  "link": null,
+  "developer_message": "This resource is restricted in the user's region.",
+  "error_code": 5451
+}

--- a/tests/mocks/mapping.json
+++ b/tests/mocks/mapping.json
@@ -12,6 +12,10 @@
         "mock": "api_channels_search.json"
     },
     {
+        "url": "search and other endpoints are blocked in most non US countries",
+        "mock": "api_geo_block.json"
+    },
+    {
         "url": "https://api.vimeo.com/groups?page=2&per_page=3&query=sport",
         "mock": "api_groups_search.json"
     },

--- a/tests/resources/lib/test_api.py
+++ b/tests/resources/lib/test_api.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, Mock
 sys.modules["xbmc"] = xbmcMock = MagicMock()
 sys.modules["xbmcaddon"] = MagicMock()
 sys.modules["xbmcgui"] = MagicMock()
-from resources.lib.api import Api, PasswordRequiredException
+from resources.lib.api import Api, PasswordRequiredException, ResourceRestrictedException
 from resources.lib.kodi.settings import Settings
 
 
@@ -329,6 +329,14 @@ class ApiTestCase(TestCase):
         self.api._do_api_request = Mock(return_value=json.loads(mock_data))
         res = self.api.resolve_media_url("/videos/123")
         self.assertEqual(res, "http://a.b/c.mp4|User-Agent=pyvimeo%201.2.0%3B%20%28http%3A//developer.vimeo.com/api/docs%29")
+
+    def test_geo_block(self):
+        with open("./tests/mocks/api_geo_block.json") as f:
+            mock_data = f.read()
+
+        self.api._do_api_request = Mock(return_value=json.loads(mock_data))
+
+        self.assertRaises(ResourceRestrictedException, self.api.search, "test", "videos")
 
     @skip("Can't easily mock the Vimeo client")
     def test_authorize(self):


### PR DESCRIPTION
Vimeo decided to geo-block API endpoints dedicated to search, channels and a lot of other things. The only thing still working are video details. So the only useful thing you can do with this addon is to share Vimeo videos with Kodi.

To make the user understand that Vimeo is blocking requests and the addon is not broken, a dedicated
error notification was added.