### PR TITLE
Fix crash when playing password-protected videos with subtitles enabled

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vimeo" name="Vimeo" version="6.0.2" provider-name="jaylinski">
+<addon id="plugin.video.vimeo" name="Vimeo" version="6.0.3" provider-name="jaylinski">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.29.0"/>
@@ -16,7 +16,10 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=220437</forum>
         <website>https://vimeo.com</website>
         <source>https://github.com/jaylinski/kodi-addon-vimeo</source>
-        <news>6.0.2 (2025-02-06)
+        <news>6.0.3 (2025-05-22)
+Fix crash when playing password-protected videos with subtitles enabled
+
+6.0.2 (2025-02-06)
 Handle Vimeo geo-blocking by displaying an error to affected users
 Don't add video to playlist when shared with addon
 Improve video-quality fallback for non-HLS video-formats

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -147,15 +147,15 @@ class Api:
         res = self._do_api_request("/videos", params)
         return self._map_json_to_collection(res)
 
-    def resolve_texttracks(self, uri):
-        res = self._do_api_request(uri, {})
+    def resolve_texttracks(self, uri, password=None):
+        res = self._do_api_request(uri, {"password": password})
         subtitles = res.get("data")
         for subtitle in subtitles:
             subtitle["srt"] = webvtt_to_srt(self._do_request(subtitle["link"]))
         return subtitles
 
     def resolve_media_url(self, uri, password=None):
-        # If we have a on-demand URL, we need to fetch the trailer and return the uri
+        # If we have an on-demand URL, we need to fetch the trailer and return the uri
         if uri.startswith("/ondemand/"):
             xbmc.log("plugin.video.vimeo::Api() Resolving on-demand", xbmc.LOGDEBUG)
             media_url = self._get_on_demand_trailer(uri)

--- a/resources/plugin.py
+++ b/resources/plugin.py
@@ -219,7 +219,7 @@ def resolve_list_item(handle, list_item, password=None, fetch_subtitles=False):
     list_item.setPath(resolved_url)
     text_tracks = list_item.getProperty("textTracks")
     if fetch_subtitles and text_tracks:
-        list_item = add_subtitles(list_item, text_tracks)
+        list_item = add_subtitles(list_item, text_tracks, password)
     xbmcplugin.setResolvedUrl(handle, succeeded=True, listitem=list_item)
 
 
@@ -231,8 +231,8 @@ def search(handle, query):
     xbmcplugin.endOfDirectory(handle)
 
 
-def add_subtitles(item, texttracks_url):
-    subtitles = api.resolve_texttracks(texttracks_url)
+def add_subtitles(item, texttracks_url, password=None):
+    subtitles = api.resolve_texttracks(texttracks_url, password)
     paths = []
     for subtitle in subtitles:
         file_name = "texttrack.{}.srt".format(subtitle["language"])


### PR DESCRIPTION
The Vimeo API now also requires a password for getting subtitles on password-protected videos.